### PR TITLE
Plugins for measured bandwidth and relay flags

### DIFF
--- a/tor_.py
+++ b/tor_.py
@@ -242,12 +242,10 @@ class TorBandwidth(TorPlugin):
             # In Stem 1.3.0 and later, get_server_descriptor() will fetch the
             # relay's own descriptor if no argument is provided, so this will
             # no longer be needed.
-            response = controller.get_info('fingerprint', None)
-            if response is None:
+            fingerprint = controller.get_info('fingerprint', None)
+            if fingerprint is None:
                 print("Error while reading fingerprint from Tor daemon", file=sys.stderr)
                 sys.exit(-1)
-
-            fingerprint = response
 
             response = controller.get_server_descriptor(fingerprint, None)
             if response is None:
@@ -266,9 +264,7 @@ class TorFlags(TorPlugin):
                  'vlabel': 'flags',
                  'category': 'Tor',
                  'info': 'Flags active for relay'}
-        labels = {}
-        for flag in stem.Flag:
-            labels[flag] = {'label': flag, 'min': 0, 'max': 1, 'type': 'GAUGE'}
+        labels = {flag: {'label': flag, 'min': 0, 'max': 1, 'type': 'GAUGE'} for flag in stem.Flag}
 
         TorPlugin.conf_from_dict(graph, labels)
 
@@ -284,12 +280,10 @@ class TorFlags(TorPlugin):
             # In Stem 1.3.0 and later, get_network_status() will fetch the
             # relay's own status entry if no argument is provided, so this will
             # no longer be needed.
-            response = controller.get_info('fingerprint', None)
-            if response is None:
+            fingerprint = controller.get_info('fingerprint', None)
+            if fingerprint is None:
                 print("Error while reading fingerprint from Tor daemon", file=sys.stderr)
                 sys.exit(-1)
-
-            fingerprint = response
 
             response = controller.get_network_status(fingerprint, None)
             if response is None:


### PR DESCRIPTION
This pull request adds two plugins:
1. Measured bandwidth AKA observed bandwidth AKA advertised bandwidth. Globe and Atlas show it as advertised bandwidth.
2. Relay flags.

I don't have a week's worth of graphs to add screenshots for the readme, but the pull request can hold for a few days until I do if that's desired.

Also added a missing shebang to circuits_by_country.py.
