### PR TITLE
Prevent peaks in traffic graph when restarting tor daemon.

### DIFF
--- a/tor_.py
+++ b/tor_.py
@@ -189,8 +189,8 @@ class TorTraffic(TorPlugin):
                  'vlabel': 'data',
                  'category': 'Tor',
                  'info': 'bytes read/written'}
-        labels = {'read': {'label': 'read', 'min': 0, 'type': 'COUNTER'},
-                  'written': {'label': 'written', 'min': 0, 'type': 'COUNTER'}}
+        labels = {'read': {'label': 'read', 'min': 0, 'type': 'DERIVE'},
+                  'written': {'label': 'written', 'min': 0, 'type': 'DERIVE'}}
 
         TorPlugin.conf_from_dict(graph, labels)
 


### PR DESCRIPTION
For not losing current data, do:
cd /var/lib/munin/&lt;DOMAIN&gt;
mv &lt;HOST&gt;-tor_traffic-read-c.rrd &lt;HOST&gt;-tor_traffic-read-d.rrd
mv &lt;HOST&gt;-tor_traffic-written-c.rrd &lt;HOST&gt;-tor_traffic-written-d.rrd
rrdtool &lt;HOST&gt;-tor_traffic-read-d.rrd --data-source-type DERIVE
rrdtool &lt;HOST&gt;-tor_traffic-written-d.rrd --data-source-type DERIVE

![image](https://cloud.githubusercontent.com/assets/1649603/5423715/d7a9abe4-82cb-11e4-95e5-ead415ffda77.png)
